### PR TITLE
Add Firebase Test Lab

### DIFF
--- a/docs/agp-9.0.0.md
+++ b/docs/agp-9.0.0.md
@@ -19,3 +19,4 @@ Release notes: https://developer.android.com/build/releases/agp-preview
 | `com.apollographql.apollo` | Broken | https://github.com/apollographql/apollo-kotlin/issues/6693 | `android.newDsl=false` | |
 | `org.gradle.android.cache-fix` | Broken | https://github.com/gradle/android-cache-fix-gradle-plugin/issues/447 | `android.newDsl=false` | [Draft PR](https://github.com/gradle/android-cache-fix-gradle-plugin/pull/1886) created but waiting for https://issuetracker.google.com/issues/443225252 | |
 | `com.jaredsburrows.license` | Broken | https://github.com/jaredsburrows/gradle-license-plugin/issues/693 | `android.newDsl=false` | |
+| `com.google.firebase.testlab` | Broken | https://issuetracker.google.com/issues/444866155 | None | |


### PR DESCRIPTION
It is currently broken because of an enforced version check, but from their git history, they also changed some AGP api usages: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:firebase/testlab/testlab-gradle-plugin/;bpv=1