### PR TITLE
Adding ACFP fix

### DIFF
--- a/docs/agp-9.0.0.md
+++ b/docs/agp-9.0.0.md
@@ -20,7 +20,7 @@ Release notes: https://developer.android.com/build/releases/agp-preview
 | `de.mannodermaus.android-junit5` | Fixed (1.13.4.0) | https://github.com/mannodermaus/android-junit5/issues/380 | `android.newDsl=false` | |
 | `com.google.android.gms:oss-licenses-plugin` | Fixed (0.10.8) | | `android.newDsl=false` | |
 | `com.apollographql.apollo` | Fixed (5.0.0-alpha.3) | https://github.com/apollographql/apollo-kotlin/issues/6693 | `android.newDsl=false` | Addressed by https://github.com/apollographql/apollo-kotlin/pull/6703 |
-| `org.gradle.android.cache-fix` | Broken | https://github.com/gradle/android-cache-fix-gradle-plugin/issues/447 | `android.newDsl=false` | [Draft PR](https://github.com/gradle/android-cache-fix-gradle-plugin/pull/1886) created but waiting for https://issuetracker.google.com/issues/443225252 | |
+| `org.gradle.android.cache-fix` | Fixed (3.0.2) | https://github.com/gradle/android-cache-fix-gradle-plugin/issues/447 | `android.newDsl=false` | Addressed by https://github.com/gradle/android-cache-fix-gradle-plugin/pull/1894 | |
 | `com.jaredsburrows.license` | Broken | https://github.com/jaredsburrows/gradle-license-plugin/issues/693 | <pre>android.newDsl=false<br>android.enableLegacyVariantApi=true</pre> | Second Gradle property should not be necessary, and only came about as of AGP 9.0.0-alpha06. |
 | `com.google.firebase.testlab` | Broken | https://issuetracker.google.com/issues/444866155 | None | |
 | `app.cash.burst` | Fixed (2.10.0) | https://github.com/cashapp/burst/issues/197 | None | Addressed by https://github.com/cashapp/burst/pull/200 |


### PR DESCRIPTION
We have released 3.0.2 adding support for the new variant api (without workaround) in our workarounds